### PR TITLE
Fix bug when reading last block during comment

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -339,9 +339,6 @@ func (lr *lineReader) readLine() (line string, e error) {
 				return string(lr.lineBuffer[0:nextCharIndex]), nil
 			}
 			if e == io.ErrUnexpectedEOF {
-				if isCommentLine {
-					return "", io.EOF
-				}
 				continue
 			}
 			if e != nil {

--- a/properties_test.go
+++ b/properties_test.go
@@ -22,17 +22,17 @@ package properties
 
 import (
 	"bytes"
-	. "launchpad.net/gocheck"
 	"math"
 	"os"
 	"testing"
+	. "launchpad.net/gocheck"
 )
 
 // Hook up gocheck into the gotest runner.
 func Test(t *testing.T) { TestingT(t) }
 
 type PropertiesSuite struct {
-	p       Properties
+	p Properties
 }
 
 var _ = Suite(&PropertiesSuite{})
@@ -86,6 +86,22 @@ func (s *PropertiesSuite) TestUint(c *C) {
 	c.Assert(s.p.Uint("uint", 42), Equals, uint64(math.MaxUint64))
 	c.Assert(s.p.Uint("missed", 42), Equals, uint64(42))
 	c.Assert(s.p.Uint("hex", 0xCAFEBABE), Equals, uint64(0xCAFEBABE))
+}
+
+// Test1024Comment verifies that if the lineReader is in the middle
+// of parsing a comment when it goes to read the last < 1024 byte block,
+// it doesn't get confused and return EOF.
+func (s *PropertiesSuite) Test1024Comment(c *C) {
+	config := "a = b\n"
+	for i := 0; i < 1024; i++ {
+		config += "#"
+	}
+	config += "\nc = d\n"
+
+	p := make(Properties)
+	p.Load(bytes.NewReader([]byte(config)))
+	c.Assert(p.String("a", "not found"), Equals, "b")
+	c.Assert(p.String("c", "not found"), Equals, "d")
 }
 
 const source = `


### PR DESCRIPTION
Hi Dmitry,

I am using your library for a project at PayPal.  I recently uncovered a bug in `lineReader`.  I just happened to have a properties file with a comment line spanning the 1K boundary.  I dug into the code and found the problem.  The test case I created demonstrates the problem and will fail without the fix.

Please accept this patch.  I'd really like to continue using your repo!

thanks,
mike
