### PR TITLE
add support for time.Duration

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -81,6 +81,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"time"
 	"unicode/utf8"
 )
 
@@ -150,6 +151,16 @@ func (p Properties) Uint(key string, def uint64) uint64 {
 func (p Properties) String(key string, def string) string {
 	if v, found := p[key]; found {
 		return v
+	}
+	return def
+}
+
+// Returns def if key does not exist.
+func (p Properties) Duration(key string, def time.Duration) time.Duration {
+	if v, found := p[key]; found {
+		if b, err := time.ParseDuration(v); err == nil {
+			return b
+		}
 	}
 	return def
 }

--- a/properties_test.go
+++ b/properties_test.go
@@ -25,6 +25,7 @@ import (
 	"math"
 	"os"
 	"testing"
+	"time"
 	. "launchpad.net/gocheck"
 )
 
@@ -88,6 +89,11 @@ func (s *PropertiesSuite) TestUint(c *C) {
 	c.Assert(s.p.Uint("hex", 0xCAFEBABE), Equals, uint64(0xCAFEBABE))
 }
 
+func (s *PropertiesSuite) TestDuration(c *C) {
+	c.Assert(s.p.Duration("duration", 42), Equals, 10*time.Millisecond)
+	c.Assert(s.p.Duration("missed", 42), Equals, time.Duration(42))
+}
+
 // Test1024Comment verifies that if the lineReader is in the middle
 // of parsing a comment when it goes to read the last < 1024 byte block,
 // it doesn't get confused and return EOF.
@@ -128,4 +134,5 @@ float=4.940656458412465441765687928682213723651e-324
 int=-9223372036854775808
 uint=18446744073709551615
 hex=0xCAFEBABE
+duration=10ms
 `


### PR DESCRIPTION
Hi Dmitry,

We frequently use properties files to configure timeouts.  Utlimately we want to convert the values into a `time.Duration`.  It turns out there is already a nice [time.ParseDuration()](http://golang.org/pkg/time/#ParseDuration) function to do all the heavy lifting.  I think it would be a great addition to your package if you would include this patch to add direct support for `time.Duration`.

thanks!
mike
